### PR TITLE
Separation on wing area constraints as submodel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ tags
 *.egg-info
 
 # Unittest and coverage
-htmlcov/*
+**/htmlcov/**
 .coverage
 .tox
 junit.xml

--- a/src/fastoad_cs25/models/loops/compute_wing_area.py
+++ b/src/fastoad_cs25/models/loops/compute_wing_area.py
@@ -17,8 +17,14 @@ Computation of wing area
 import numpy as np
 import openmdao.api as om
 from fastoad.module_management.constants import ModelDomain
-from fastoad.module_management.service_registry import RegisterOpenMDAOSystem
-from scipy.constants import g
+from fastoad.module_management.service_registry import RegisterOpenMDAOSystem, RegisterSubmodel
+
+from .constants import (
+    SERVICE_WING_AREA_LOOP_GEOM,
+    SERVICE_WING_AREA_LOOP_AERO,
+    SERVICE_WING_AREA_CONSTRAINT_GEOM,
+    SERVICE_WING_AREA_CONSTRAINT_AERO,
+)
 
 
 @RegisterOpenMDAOSystem("fastoad.loop.wing_area", domain=ModelDomain.OTHER)
@@ -30,87 +36,65 @@ class ComputeWingArea(om.Group):
     """
 
     def setup(self):
-        self.add_subsystem("wing_area", _ComputeWingArea(), promotes=["*"])
-        self.add_subsystem("constraints", _ComputeWingAreaConstraints(), promotes=["*"])
+        self.add_subsystem(
+            "wing_area_geom",
+            RegisterSubmodel.get_submodel(SERVICE_WING_AREA_LOOP_GEOM),
+            promotes_inputs=["*"],
+            promotes_outputs=[],
+        )
+        self.add_subsystem(
+            "wing_area_aero",
+            RegisterSubmodel.get_submodel(SERVICE_WING_AREA_LOOP_AERO),
+            promotes_inputs=["*"],
+            promotes_outputs=[],
+        )
+        self.add_subsystem(
+            "wing_area", _ComputeWingArea(), promotes_inputs=[], promotes_outputs=["*"]
+        )
+        self.add_subsystem(
+            "geom_constraint",
+            RegisterSubmodel.get_submodel(SERVICE_WING_AREA_CONSTRAINT_GEOM),
+            promotes=["*"],
+        )
+        self.add_subsystem(
+            "aero_constraint",
+            RegisterSubmodel.get_submodel(SERVICE_WING_AREA_CONSTRAINT_AERO),
+            promotes=["*"],
+        )
+
+        self.connect("wing_area_geom.wing_area:geom", "wing_area.wing_area:geom")
+        self.connect("wing_area_aero.wing_area:aero", "wing_area.wing_area:aero")
 
 
 class _ComputeWingArea(om.ExplicitComponent):
-    """Computation of wing area from needed approach speed and mission fuel"""
+    """
+    Computation of wing area from needed approach speed and mission fuel and taking whichever
+    is greatest
+    """
 
     def setup(self):
-        self.add_input("data:geometry:wing:aspect_ratio", val=np.nan)
-        self.add_input("data:geometry:wing:root:thickness_ratio", val=np.nan)
-        self.add_input("data:geometry:wing:tip:thickness_ratio", val=np.nan)
-        self.add_input("data:weight:aircraft:sizing_block_fuel", val=np.nan, units="kg")
-        self.add_input("data:TLAR:approach_speed", val=np.nan, units="m/s")
-
-        self.add_input("data:weight:aircraft:MLW", val=np.nan, units="kg")
-        self.add_input("data:aerodynamics:aircraft:landing:CL_max", val=np.nan)
+        self.add_input("wing_area:aero", units="m**2", val=np.nan)
+        self.add_input("wing_area:geom", units="m**2", val=np.nan)
 
         self.add_output("data:geometry:wing:area", val=100.0, units="m**2")
 
-    def setup_partials(self):
-        self.declare_partials("data:geometry:wing:area", "*", method="fd")
+        self.declare_partials(of="*", wrt="*", method="exact")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
-        lambda_wing = inputs["data:geometry:wing:aspect_ratio"]
-        root_thickness_ratio = inputs["data:geometry:wing:root:thickness_ratio"]
-        tip_thickness_ratio = inputs["data:geometry:wing:tip:thickness_ratio"]
-        mfw_mission = inputs["data:weight:aircraft:sizing_block_fuel"]
-        wing_area_mission = (
-            max(1000.0, mfw_mission - 1570.0)
-            / 224
-            / lambda_wing**-0.4
-            / (0.6 * root_thickness_ratio + 0.4 * tip_thickness_ratio)
-        ) ** (1.0 / 1.5)
 
-        approach_speed = inputs["data:TLAR:approach_speed"]
-        mlw = inputs["data:weight:aircraft:MLW"]
-        max_CL = inputs["data:aerodynamics:aircraft:landing:CL_max"]
-        wing_area_approach = 2 * mlw * g / ((approach_speed / 1.23) ** 2) / (1.225 * max_CL)
+        wing_area_mission = inputs["wing_area:geom"]
+        wing_area_approach = inputs["wing_area:aero"]
 
         outputs["data:geometry:wing:area"] = np.nanmax([wing_area_mission, wing_area_approach])
 
+    def compute_partials(self, inputs, partials, discrete_inputs=None):
 
-class _ComputeWingAreaConstraints(om.ExplicitComponent):
-    def setup(self):
-        self.add_input("data:weight:aircraft:sizing_block_fuel", val=np.nan, units="kg")
-        self.add_input("data:weight:aircraft:MFW", val=np.nan, units="kg")
+        wing_area_mission = inputs["wing_area:geom"]
+        wing_area_approach = inputs["wing_area:aero"]
 
-        self.add_input("data:TLAR:approach_speed", val=np.nan, units="m/s")
-        self.add_input("data:weight:aircraft:MLW", val=np.nan, units="kg")
-        self.add_input("data:aerodynamics:aircraft:landing:CL_max", val=np.nan)
-        self.add_input("data:geometry:wing:area", val=np.nan, units="m**2")
-
-        self.add_output("data:weight:aircraft:additional_fuel_capacity", units="kg")
-        self.add_output("data:aerodynamics:aircraft:landing:additional_CL_capacity")
-
-    def setup_partials(self):
-        self.declare_partials(
-            "data:weight:aircraft:additional_fuel_capacity",
-            ["data:weight:aircraft:MFW", "data:weight:aircraft:sizing_block_fuel"],
-            method="fd",
-        )
-        self.declare_partials(
-            "data:aerodynamics:aircraft:landing:additional_CL_capacity",
-            [
-                "data:TLAR:approach_speed",
-                "data:weight:aircraft:MLW",
-                "data:aerodynamics:aircraft:landing:CL_max",
-                "data:geometry:wing:area",
-            ],
-            method="fd",
-        )
-
-    def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
-        mfw = inputs["data:weight:aircraft:MFW"]
-        mission_fuel = inputs["data:weight:aircraft:sizing_block_fuel"]
-        v_approach = inputs["data:TLAR:approach_speed"]
-        cl_max = inputs["data:aerodynamics:aircraft:landing:CL_max"]
-        mlw = inputs["data:weight:aircraft:MLW"]
-        wing_area = inputs["data:geometry:wing:area"]
-
-        outputs["data:weight:aircraft:additional_fuel_capacity"] = mfw - mission_fuel
-        outputs["data:aerodynamics:aircraft:landing:additional_CL_capacity"] = cl_max - mlw * g / (
-            0.5 * 1.225 * (v_approach / 1.23) ** 2 * wing_area
-        )
+        if wing_area_mission > wing_area_approach:
+            partials["data:geometry:wing:area", "wing_area:geom"] = 1.0
+            partials["data:geometry:wing:area", "wing_area:aero"] = 0.0
+        else:
+            partials["data:geometry:wing:area", "wing_area:geom"] = 0.0
+            partials["data:geometry:wing:area", "wing_area:aero"] = 1.0

--- a/src/fastoad_cs25/models/loops/constants.py
+++ b/src/fastoad_cs25/models/loops/constants.py
@@ -1,0 +1,20 @@
+"""
+Constants for loops submodels
+"""
+#  This file is part of FAST-OAD_CS25
+#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+SERVICE_WING_AREA_LOOP_AERO = "service.loops.wing.area.update.aero"
+SERVICE_WING_AREA_LOOP_GEOM = "service.loops.wing.area.update.geom"
+SERVICE_WING_AREA_CONSTRAINT_AERO = "service.loops.wing.area.constraint.aero"
+SERVICE_WING_AREA_CONSTRAINT_GEOM = "service.loops.wing.area.constraint.geom"

--- a/src/fastoad_cs25/models/loops/wing_area_component/update_wing_area_aero.py
+++ b/src/fastoad_cs25/models/loops/wing_area_component/update_wing_area_aero.py
@@ -1,0 +1,120 @@
+"""
+Computation of wing area following aerodynamic constraints
+"""
+#  This file is part of FAST-OAD_CS25
+#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import numpy as np
+import openmdao.api as om
+from scipy.constants import g
+from fastoad.module_management.service_registry import RegisterSubmodel
+from fastoad_cs25.models.loops.constants import (
+    SERVICE_WING_AREA_LOOP_AERO,
+    SERVICE_WING_AREA_CONSTRAINT_AERO,
+)
+
+
+@RegisterSubmodel(
+    SERVICE_WING_AREA_LOOP_AERO, "fastoad.submodel.loops.wing.area.update.aero.legacy"
+)
+class UpdateWingAreaAero(om.ExplicitComponent):
+    """Computes wing area for having enough lift at required approach speed."""
+
+    def setup(self):
+
+        self.add_input("data:TLAR:approach_speed", val=np.nan, units="m/s")
+        self.add_input("data:weight:aircraft:MLW", val=np.nan, units="kg")
+        self.add_input("data:aerodynamics:aircraft:landing:CL_max", val=np.nan)
+
+        # My plan is to not promote this variable and connect it by hand so that it foes not
+        # appear in the output file as is but only as a constraints in the other component. We
+        # could however give it a proper name.
+        self.add_output("wing_area:aero", val=100.0, units="m**2")
+
+        self.declare_partials(of="*", wrt="*", method="exact")
+
+    def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
+
+        approach_speed = inputs["data:TLAR:approach_speed"]
+        mlw = inputs["data:weight:aircraft:MLW"]
+        max_CL = inputs["data:aerodynamics:aircraft:landing:CL_max"]
+        wing_area_approach = 2 * mlw * g / ((approach_speed / 1.23) ** 2) / (1.225 * max_CL)
+
+        outputs["wing_area:aero"] = wing_area_approach
+
+    def compute_partials(self, inputs, partials, discrete_inputs=None):
+
+        approach_speed = inputs["data:TLAR:approach_speed"]
+        mlw = inputs["data:weight:aircraft:MLW"]
+        max_CL = inputs["data:aerodynamics:aircraft:landing:CL_max"]
+
+        partials["wing_area:aero", "data:TLAR:approach_speed"] = (
+            -4 * mlw * g / ((approach_speed / 1.23) ** 3) / (1.225 * max_CL) / 1.23
+        )
+        partials["wing_area:aero", "data:weight:aircraft:MLW"] = (
+            2 * g / ((approach_speed / 1.23) ** 2) / (1.225 * max_CL)
+        )
+        partials["wing_area:aero", "data:aerodynamics:aircraft:landing:CL_max"] = (
+            -2 * mlw * g / ((approach_speed / 1.23) ** 2) / (1.225 * max_CL**2)
+        )
+
+
+@RegisterSubmodel(
+    SERVICE_WING_AREA_CONSTRAINT_AERO, "fastoad.submodel.loops.wing.area.constraint.aero.legacy"
+)
+class WingAreaConstraintsAero(om.ExplicitComponent):
+    def setup(self):
+
+        self.add_input("data:TLAR:approach_speed", val=np.nan, units="m/s")
+        self.add_input("data:weight:aircraft:MLW", val=np.nan, units="kg")
+        self.add_input("data:aerodynamics:aircraft:landing:CL_max", val=np.nan)
+        self.add_input("data:geometry:wing:area", val=np.nan, units="m**2")
+
+        self.add_output("data:aerodynamics:aircraft:landing:additional_CL_capacity")
+
+        self.declare_partials(of="*", wrt="*", method="exact")
+
+    def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
+
+        v_approach = inputs["data:TLAR:approach_speed"]
+        cl_max = inputs["data:aerodynamics:aircraft:landing:CL_max"]
+        mlw = inputs["data:weight:aircraft:MLW"]
+        wing_area = inputs["data:geometry:wing:area"]
+
+        outputs["data:aerodynamics:aircraft:landing:additional_CL_capacity"] = cl_max - mlw * g / (
+            0.5 * 1.225 * (v_approach / 1.23) ** 2 * wing_area
+        )
+
+    def compute_partials(self, inputs, partials, discrete_inputs=None):
+
+        v_approach = inputs["data:TLAR:approach_speed"]
+        mlw = inputs["data:weight:aircraft:MLW"]
+        wing_area = inputs["data:geometry:wing:area"]
+
+        partials[
+            "data:aerodynamics:aircraft:landing:additional_CL_capacity", "data:TLAR:approach_speed"
+        ] = (2 * mlw * g / (0.5 * 1.225 * (v_approach / 1.23) ** 3 * wing_area) / 1.23)
+        partials[
+            "data:aerodynamics:aircraft:landing:additional_CL_capacity",
+            "data:aerodynamics:aircraft:landing:CL_max",
+        ] = 1
+        partials[
+            "data:aerodynamics:aircraft:landing:additional_CL_capacity",
+            "data:weight:aircraft:MLW",
+        ] = -g / (0.5 * 1.225 * (v_approach / 1.23) ** 2 * wing_area)
+        partials[
+            "data:aerodynamics:aircraft:landing:additional_CL_capacity",
+            "data:geometry:wing:area",
+        ] = (
+            mlw * g / (0.5 * 1.225 * (v_approach / 1.23) ** 2 * wing_area**2.0)
+        )

--- a/src/fastoad_cs25/models/loops/wing_area_component/update_wing_area_geom.py
+++ b/src/fastoad_cs25/models/loops/wing_area_component/update_wing_area_geom.py
@@ -1,0 +1,130 @@
+"""
+Computation of wing area following geometric constraints
+"""
+#  This file is part of FAST-OAD_CS25
+#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import numpy as np
+import openmdao.api as om
+from fastoad.module_management.service_registry import RegisterSubmodel
+from fastoad_cs25.models.loops.constants import (
+    SERVICE_WING_AREA_LOOP_GEOM,
+    SERVICE_WING_AREA_CONSTRAINT_GEOM,
+)
+
+
+@RegisterSubmodel(
+    SERVICE_WING_AREA_LOOP_GEOM, "fastoad.submodel.loops.wing.area.update.geom.legacy"
+)
+class UpdateWingAreaGeom(om.ExplicitComponent):
+    """Computes wing area for being able to load enough fuel to achieve the sizing mission."""
+
+    def setup(self):
+        self.add_input("data:geometry:wing:aspect_ratio", val=np.nan)
+        self.add_input("data:geometry:wing:root:thickness_ratio", val=np.nan)
+        self.add_input("data:geometry:wing:tip:thickness_ratio", val=np.nan)
+        self.add_input("data:weight:aircraft:sizing_block_fuel", val=np.nan, units="kg")
+
+        # Same remark on the naming and connection as in the aero component
+        self.add_output("wing_area:geom", val=100.0, units="m**2")
+
+        self.declare_partials(of="*", wrt="*", method="exact")
+
+    def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
+        lambda_wing = inputs["data:geometry:wing:aspect_ratio"]
+        root_thickness_ratio = inputs["data:geometry:wing:root:thickness_ratio"]
+        tip_thickness_ratio = inputs["data:geometry:wing:tip:thickness_ratio"]
+        mfw_mission = inputs["data:weight:aircraft:sizing_block_fuel"]
+        wing_area_mission = (
+            max(1000.0, mfw_mission - 1570.0)
+            / 224
+            / lambda_wing**-0.4
+            / (0.6 * root_thickness_ratio + 0.4 * tip_thickness_ratio)
+        ) ** (1.0 / 1.5)
+
+        outputs["wing_area:geom"] = wing_area_mission
+
+    def compute_partials(self, inputs, partials, discrete_inputs=None):
+
+        lambda_wing = inputs["data:geometry:wing:aspect_ratio"]
+        root_thickness_ratio = inputs["data:geometry:wing:root:thickness_ratio"]
+        tip_thickness_ratio = inputs["data:geometry:wing:tip:thickness_ratio"]
+        mfw_mission = inputs["data:weight:aircraft:sizing_block_fuel"]
+
+        partials["wing_area:geom", "data:geometry:wing:aspect_ratio"] = (
+            (
+                max(1000.0, mfw_mission - 1570.0)
+                / 224
+                / (0.6 * root_thickness_ratio + 0.4 * tip_thickness_ratio)
+            )
+            ** (1.0 / 1.5)
+            * (0.4 / 1.5)
+            * lambda_wing ** (0.4 / 1.5 - 1.0)
+        )
+        partials["wing_area:geom", "data:geometry:wing:root:thickness_ratio"] = (
+            (max(1000.0, mfw_mission - 1570.0) / 224 / lambda_wing**-0.4) ** (1.0 / 1.5)
+            * (-1.0 / 1.5)
+            * (0.6 * root_thickness_ratio + 0.4 * tip_thickness_ratio) ** (-1.0 / 1.5 - 1.0)
+        ) * 0.6
+        partials["wing_area:geom", "data:geometry:wing:tip:thickness_ratio"] = (
+            (max(1000.0, mfw_mission - 1570.0) / 224 / lambda_wing**-0.4) ** (1.0 / 1.5)
+            * (-1.0 / 1.5)
+            * (0.6 * root_thickness_ratio + 0.4 * tip_thickness_ratio) ** (-1.0 / 1.5 - 1.0)
+        ) * 0.4
+        if mfw_mission < 1000.0:
+            partials["wing_area:geom", "data:weight:aircraft:sizing_block_fuel"] = 0.0
+        else:
+            partials["wing_area:geom", "data:weight:aircraft:sizing_block_fuel"] = (
+                (
+                    1.0
+                    / 224
+                    / lambda_wing**-0.4
+                    / (0.6 * root_thickness_ratio + 0.4 * tip_thickness_ratio)
+                )
+                ** (1.0 / 1.5)
+                * (1.0 / 1.5)
+                * (mfw_mission - 1570.0) ** (1.0 / 1.5 - 1.0)
+            )
+
+
+@RegisterSubmodel(
+    SERVICE_WING_AREA_CONSTRAINT_GEOM, "fastoad.submodel.loops.wing.area.constraint.geom.legacy"
+)
+class WingAreaConstraintsGeom(om.ExplicitComponent):
+    def setup(self):
+        self.add_input("data:weight:aircraft:sizing_block_fuel", val=np.nan, units="kg")
+        self.add_input("data:weight:aircraft:MFW", val=np.nan, units="kg")
+
+        self.add_output("data:weight:aircraft:additional_fuel_capacity")
+
+        self.declare_partials(of="*", wrt="*", method="exact")
+
+    def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
+
+        mfw = inputs["data:weight:aircraft:MFW"]
+        mission_fuel = inputs["data:weight:aircraft:sizing_block_fuel"]
+
+        # The MFW is not updated between the moment we get our new wing area and the moment we
+        # compute the constraints, is this a problem ? The final value in the xml will be
+        # accurate because it will be the results once converged but for an optimization where we
+        # do not loop and only check constraints this might be an issue.
+
+        outputs["data:weight:aircraft:additional_fuel_capacity"] = mfw - mission_fuel
+
+    def compute_partials(self, inputs, partials, discrete_inputs=None):
+
+        partials[
+            "data:weight:aircraft:additional_fuel_capacity",
+            "data:weight:aircraft:sizing_block_fuel",
+        ] = -1
+        partials["data:weight:aircraft:additional_fuel_capacity", "data:weight:aircraft:MFW"] = 1


### PR DESCRIPTION
Separated the models used for the update on the wing area in 4 submodels : two updates and two constraints. One pair for each type of constraints, here aerodynamic (low speed CL_max) and geometric (enough space to store the fuel inside the wings). 
The value of the unit test have not been changed, proof that both method are equivalent in results and the partials that were added have been check with the check_partials() function on the problem created by the run_system inside the unit tests.